### PR TITLE
Fix hero heading clipping on mobile

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -164,7 +164,7 @@ body {
 }
 
 .hero-title {
-    font-size: 3.5rem;
+    font-size: clamp(2rem, 5vw + 1rem, 3.5rem);
     font-weight: 700;
     line-height: 1.1;
     margin-bottom: 1.5rem;
@@ -682,10 +682,11 @@ body {
         grid-template-columns: 1fr;
         text-align: center;
         gap: 2rem;
+        padding: 0 1.5rem;
     }
     
     .hero-title {
-        font-size: 2.5rem;
+        line-height: 1.2;
     }
     
     .hero-buttons {
@@ -756,9 +757,9 @@ body {
 
 @media (max-width: 480px) {
     .hero-title {
-        font-size: 2rem;
+        font-size: clamp(1.75rem, 9vw, 2.25rem);
     }
-    
+
     .section-title {
         font-size: 2rem;
     }


### PR DESCRIPTION
## Summary
- adjust hero heading font sizes with clamp to scale smoothly across viewports
- tweak mobile hero layout spacing to prevent clipping on narrow screens

## Testing
- no automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d8e68bc69483308e4419928741f4b8